### PR TITLE
Fix in-memory snapshot retrieval

### DIFF
--- a/Framework/src/Ncqrs.Tests/Eventing/Storage/InMemoryEventStoreSpecs.cs
+++ b/Framework/src/Ncqrs.Tests/Eventing/Storage/InMemoryEventStoreSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Ncqrs.Eventing.Sourcing;
+using Ncqrs.Eventing.Storage.NoDB.Tests.Fakes;
 using NUnit.Framework;
 using Ncqrs.Eventing.Storage;
 
@@ -99,6 +100,36 @@ namespace Ncqrs.Tests.Eventing.Storage
 
             events.Count().Should().Be(unionOfStoredEvents.Count());
             events.Should().BeEquivalentTo(unionOfStoredEvents);
+        }
+
+        [Test]
+        public void When_getting_a_snapshot_from_a_non_existing_event_source_the_result_should_be_null()
+        {
+            var eventSourceId = Guid.NewGuid();
+            var store = new InMemoryEventStore();
+
+            var snapshot = store.GetSnapshot(eventSourceId);
+
+            snapshot.Should().BeNull();
+        }
+
+        [Test]
+        public void When_getting_a_snapshot_that_was_saved_it_should_return_the_snapshot()
+        {
+            var eventSourceId = Guid.NewGuid();
+            var store = new InMemoryEventStore();
+            var expectedSnapshot = new TestSnapshot
+                                       {
+                                           EventSourceId = eventSourceId,
+                                           EventSourceVersion = 1,
+                                           Name = "Test"
+                                       };
+
+            store.SaveShapshot(expectedSnapshot);
+
+            var snapshot = store.GetSnapshot(eventSourceId);
+
+            snapshot.Should().Be(expectedSnapshot);
         }
     }
 }

--- a/Framework/src/Ncqrs/Eventing/Storage/InMemoryEventStore.cs
+++ b/Framework/src/Ncqrs/Eventing/Storage/InMemoryEventStore.cs
@@ -78,7 +78,8 @@ namespace Ncqrs.Eventing.Storage
         /// </summary>
         public ISnapshot GetSnapshot(Guid eventSourceId)
         {
-            return _snapshots[eventSourceId];
+            ISnapshot snapshot;
+            return _snapshots.TryGetValue(eventSourceId, out snapshot) ? snapshot : null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent the in-memory event store from throwing when a snapshot does not exist
- add coverage to ensure null is returned for missing snapshots and saved snapshots are retrieved

## Testing
- `dotnet test Framework/NcqrsFramework.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d81a6c0d848320b8c71e85343de395